### PR TITLE
Align Agent Lee provider options with server support

### DIFF
--- a/app/agent-lee/page.tsx
+++ b/app/agent-lee/page.tsx
@@ -75,7 +75,7 @@ interface Message {
 export default function AgentLeePage() {
   const { data: session, status } = useSession()
   const [isMenuOpen, setIsMenuOpen] = useState(false)
-  const [apiProvider, setApiProvider] = useState<'openai' | 'deepseek'>('openai')
+  const [apiProvider, setApiProvider] = useState<'openai' | 'mistral'>('openai')
   const [messages, setMessages] = useState<Message[]>([
     {
       id: 1,
@@ -746,11 +746,11 @@ export default function AgentLeePage() {
                 </Button>
                 <Button
                   size="sm"
-                  variant={apiProvider === 'deepseek' ? 'default' : 'outline'}
-                  onClick={() => setApiProvider('deepseek')}
-                  className={apiProvider === 'deepseek' ? 'bg-blue-600 hover:bg-blue-700' : 'border-gray-600 text-gray-300'}
+                  variant={apiProvider === 'mistral' ? 'default' : 'outline'}
+                  onClick={() => setApiProvider('mistral')}
+                  className={apiProvider === 'mistral' ? 'bg-blue-600 hover:bg-blue-700' : 'border-gray-600 text-gray-300'}
                 >
-                  DeepSeek
+                  Mistral
                 </Button>
               </div>
             </div>

--- a/app/api/agent-lee/route.ts
+++ b/app/api/agent-lee/route.ts
@@ -558,9 +558,28 @@ export async function POST(request: NextRequest) {
       console.log("[v0] Authenticated user:", userId)
     }
 
-    const { message, threadId, lastImage, apiProvider = 'openai' } = await request.json()
+    const requestBody = await request.json()
+    const { message, threadId, lastImage } = requestBody
+    const requestedProvider =
+      typeof requestBody.apiProvider === 'string' && requestBody.apiProvider.trim().length > 0
+        ? requestBody.apiProvider.trim().toLowerCase()
+        : 'openai'
+
+    if (requestedProvider !== 'openai' && requestedProvider !== 'mistral') {
+      console.log("[v0] Unsupported API provider requested:", requestBody.apiProvider)
+      return NextResponse.json({
+        error: "Unsupported API provider",
+        details: {
+          requested: requestBody.apiProvider ?? 'unknown',
+          supported: ['openai', 'mistral']
+        }
+      }, { status: 400 })
+    }
+
+    const apiProvider = requestedProvider as 'openai' | 'mistral'
     console.log("[v0] Received message:", message, "threadId:", threadId)
     console.log("[v0] Has last image for context:", !!lastImage)
+    console.log("[v0] API provider in use:", apiProvider)
 
     if (!message || typeof message !== "string") {
       console.log("[v0] Invalid message format")


### PR DESCRIPTION
## Summary
- rename the Agent Lee provider selector option from DeepSeek to Mistral so the client only sends supported provider values
- validate the requested provider in the Agent Lee API route, log the active provider, and bail out early on unsupported values

## Testing
- npm run lint *(fails: Invalid Options – repo uses removed Next lint settings)*
- npm run dev *(used for manual API verification; stopped with Ctrl+C after curl checks)*

------
https://chatgpt.com/codex/tasks/task_e_68c9bc7145a08320872f6865377ac923