### PR TITLE
Harden admin endpoints and internal API keys

### DIFF
--- a/app/api/admin/courses/route.ts
+++ b/app/api/admin/courses/route.ts
@@ -1,16 +1,12 @@
 import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
-import { getServerSession } from 'next-auth'
+import { AdminAuthorizationError, requireAdmin } from '@/lib/auth'
 
 export const dynamic = 'force-dynamic'
 
 export async function GET() {
   try {
-    // Check if user is admin (you can implement proper auth check)
-    // const session = await getServerSession()
-    // if (!session || session.user.role !== 'admin') {
-    //   return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-    // }
+    await requireAdmin()
 
     const courses = await prisma.courses.findMany({
       include: {
@@ -52,6 +48,9 @@ export async function GET() {
 
     return NextResponse.json(coursesWithStats)
   } catch (error) {
+    if (error instanceof AdminAuthorizationError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
     console.error('Failed to fetch courses:', error)
     return NextResponse.json(
       { error: 'Internal server error' },
@@ -62,11 +61,7 @@ export async function GET() {
 
 export async function POST(request: Request) {
   try {
-    // Check if user is admin
-    // const session = await getServerSession()
-    // if (!session || session.user.role !== 'admin') {
-    //   return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-    // }
+    await requireAdmin()
 
     const data = await request.json()
 
@@ -94,6 +89,9 @@ export async function POST(request: Request) {
 
     return NextResponse.json(course)
   } catch (error) {
+    if (error instanceof AdminAuthorizationError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
     console.error('Failed to create course:', error)
     return NextResponse.json(
       { error: 'Internal server error' },

--- a/app/api/agent-lee/route.ts
+++ b/app/api/agent-lee/route.ts
@@ -1266,12 +1266,22 @@ export async function POST(request: NextRequest) {
         console.log("[v0] Starting code generation with Anthropic")
         const codegenStartTime = Date.now()
 
+        const internalApiKey = process.env.INTERNAL_API_KEY
+
+        if (!internalApiKey) {
+          console.error("[v0] Internal API key not configured for code generation")
+          return NextResponse.json({
+            error: "Code generation not available",
+            details: "Internal API key not configured"
+          }, { status: 500 })
+        }
+
         // Call our internal codegen API
         const codegenResponse = await fetch(`${process.env.NEXTAUTH_URL || 'http://localhost:3000'}/api/anthropic/codegen`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            'Authorization': `Bearer ${process.env.INTERNAL_API_KEY || 'agent-lee-internal'}`
+            'Authorization': `Bearer ${internalApiKey}`
           },
           body: JSON.stringify({
             instruction: message,

--- a/app/api/anthropic/codegen/route.ts
+++ b/app/api/anthropic/codegen/route.ts
@@ -5,7 +5,15 @@ export async function POST(request: NextRequest) {
   try {
     // Basic authentication - ensure this is called from Agent Lee
     const authHeader = request.headers.get('authorization')
-    const internalKey = process.env.INTERNAL_API_KEY || 'agent-lee-internal'
+    const internalKey = process.env.INTERNAL_API_KEY
+
+    if (!internalKey) {
+      console.error('[Codegen API] INTERNAL_API_KEY is not configured')
+      return NextResponse.json(
+        { error: 'Internal API key not configured' },
+        { status: 500 }
+      )
+    }
 
     if (!authHeader || authHeader !== `Bearer ${internalKey}`) {
       return NextResponse.json(

--- a/app/api/emails/admin/route.ts
+++ b/app/api/emails/admin/route.ts
@@ -2,9 +2,17 @@ import { NextRequest, NextResponse } from 'next/server'
 
 export async function GET(request: NextRequest) {
   try {
-    // Simple admin authentication (you can enhance this)
+    const adminKey = process.env.EMAIL_ADMIN_KEY
+
+    if (!adminKey) {
+      console.error('Email admin key is not configured')
+      return NextResponse.json(
+        { error: 'Email admin key not configured' },
+        { status: 500 }
+      )
+    }
+
     const authHeader = request.headers.get('authorization')
-    const adminKey = process.env.EMAIL_ADMIN_KEY || 'admin123' // Set this in your .env.local
 
     if (!authHeader || authHeader !== `Bearer ${adminKey}`) {
       return NextResponse.json(
@@ -58,9 +66,17 @@ export async function GET(request: NextRequest) {
 
 export async function DELETE(request: NextRequest) {
   try {
-    // Authentication check
+    const adminKey = process.env.EMAIL_ADMIN_KEY
+
+    if (!adminKey) {
+      console.error('Email admin key is not configured')
+      return NextResponse.json(
+        { error: 'Email admin key not configured' },
+        { status: 500 }
+      )
+    }
+
     const authHeader = request.headers.get('authorization')
-    const adminKey = process.env.EMAIL_ADMIN_KEY || 'admin123'
 
     if (!authHeader || authHeader !== `Bearer ${adminKey}`) {
       return NextResponse.json(

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,0 +1,43 @@
+import { getServerSession } from 'next-auth'
+import type { Session } from 'next-auth'
+
+import { authOptions } from '@/app/api/auth/[...nextauth]/route'
+
+export class AdminAuthorizationError extends Error {
+  status: number
+
+  constructor(message: string, status: number) {
+    super(message)
+    this.name = 'AdminAuthorizationError'
+    this.status = status
+  }
+}
+
+function getConfiguredAdminEmails(): string[] {
+  const configured = process.env.ADMIN_EMAILS
+    ?.split(',')
+    .map((email) => email.trim())
+    .filter(Boolean)
+
+  if (configured && configured.length > 0) {
+    return configured
+  }
+
+  return ['leeakpareva@gmail.com']
+}
+
+export async function requireAdmin(): Promise<Session> {
+  const session = await getServerSession(authOptions)
+
+  if (!session?.user?.email) {
+    throw new AdminAuthorizationError('Authentication required', 401)
+  }
+
+  const adminEmails = getConfiguredAdminEmails()
+
+  if (!adminEmails.includes(session.user.email)) {
+    throw new AdminAuthorizationError('Forbidden', 403)
+  }
+
+  return session
+}

--- a/tests/api/admin-courses.test.ts
+++ b/tests/api/admin-courses.test.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { findMany, createCourse, userProgressCount } = vi.hoisted(() => ({
+  findMany: vi.fn(),
+  createCourse: vi.fn(),
+  userProgressCount: vi.fn()
+}))
+
+const { mockRequireAdmin, AdminAuthorizationError } = vi.hoisted(() => {
+  class AdminAuthError extends Error {
+    status: number
+
+    constructor(message: string, status: number) {
+      super(message)
+      this.name = 'AdminAuthorizationError'
+      this.status = status
+    }
+  }
+
+  return {
+    mockRequireAdmin: vi.fn(),
+    AdminAuthorizationError: AdminAuthError
+  }
+})
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    courses: {
+      findMany,
+      create: createCourse
+    },
+    user_progress: {
+      count: userProgressCount
+    }
+  }
+}))
+
+vi.mock('@/lib/auth', () => ({
+  AdminAuthorizationError,
+  requireAdmin: (...args: unknown[]) => mockRequireAdmin(...args)
+}))
+
+import { GET, POST } from '../../app/api/admin/courses/route'
+
+describe('Admin courses API', () => {
+  beforeEach(() => {
+    mockRequireAdmin.mockReset()
+    findMany.mockReset()
+    createCourse.mockReset()
+    userProgressCount.mockReset()
+  })
+
+  it('rejects unauthenticated access to GET', async () => {
+    mockRequireAdmin.mockRejectedValueOnce(new AdminAuthorizationError('Authentication required', 401))
+
+    const response = await GET()
+    const body = await response.json()
+
+    expect(response.status).toBe(401)
+    expect(body.error).toBe('Authentication required')
+    expect(mockRequireAdmin).toHaveBeenCalled()
+  })
+
+  it('rejects non-admin access to GET', async () => {
+    mockRequireAdmin.mockRejectedValueOnce(new AdminAuthorizationError('Forbidden', 403))
+
+    const response = await GET()
+    const body = await response.json()
+
+    expect(response.status).toBe(403)
+    expect(body.error).toBe('Forbidden')
+    expect(mockRequireAdmin).toHaveBeenCalled()
+  })
+
+  it('returns courses with stats for admin', async () => {
+    mockRequireAdmin.mockResolvedValueOnce({ user: { email: 'admin@example.com' } })
+
+    findMany.mockResolvedValueOnce([
+      {
+        id: 'course-1',
+        title: 'Course 1',
+        description: 'Desc',
+        shortDescription: 'Short',
+        duration: '4 weeks',
+        difficulty: 'Beginner',
+        category: 'General',
+        isFreeTier: true,
+        price: null,
+        featured: false,
+        published: true,
+        thumbnailUrl: null,
+        instructorId: null,
+        prerequisites: null,
+        learningOutcomes: '',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        _count: {
+          user_progress: 2,
+          lessons: 4
+        }
+      }
+    ])
+    userProgressCount.mockResolvedValueOnce(1)
+
+    const response = await GET()
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(Array.isArray(data)).toBe(true)
+    expect(data[0].enrollmentCount).toBe(2)
+    expect(data[0].completionRate).toBe(50)
+    expect(data[0].lessonCount).toBe(4)
+  })
+
+  it('rejects non-admin course creation', async () => {
+    mockRequireAdmin.mockRejectedValueOnce(new AdminAuthorizationError('Forbidden', 403))
+
+    const request = new Request('http://localhost/api/admin/courses', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        title: 'Course',
+        description: 'Desc'
+      })
+    })
+
+    const response = await POST(request)
+    const body = await response.json()
+
+    expect(response.status).toBe(403)
+    expect(body.error).toBe('Forbidden')
+    expect(createCourse).not.toHaveBeenCalled()
+    expect(mockRequireAdmin).toHaveBeenCalled()
+  })
+
+  it('creates course for admin', async () => {
+    mockRequireAdmin.mockResolvedValueOnce({ user: { email: 'admin@example.com' } })
+
+    createCourse.mockResolvedValueOnce({
+      id: 'new-course',
+      title: 'Course',
+      description: 'Desc'
+    })
+
+    const request = new Request('http://localhost/api/admin/courses', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        title: 'Course',
+        description: 'Desc'
+      })
+    })
+
+    const response = await POST(request)
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.id).toBe('new-course')
+    expect(createCourse).toHaveBeenCalled()
+  })
+})

--- a/tests/api/codegen.test.ts
+++ b/tests/api/codegen.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+const { runCodegenTask, trackCodeGeneration } = vi.hoisted(() => ({
+  runCodegenTask: vi.fn(),
+  trackCodeGeneration: vi.fn()
+}))
+
+vi.mock('@/lib/anthropic/codegenAnthropic', () => ({
+  runCodegenTask
+}))
+
+vi.mock('@/lib/analytics', () => ({
+  trackCodeGeneration
+}))
+
+import { POST } from '../../app/api/anthropic/codegen/route'
+
+describe('Anthropic codegen API', () => {
+  const originalInternal = process.env.INTERNAL_API_KEY
+  const originalAnthropic = process.env.ANTHROPIC_API_KEY
+
+  beforeEach(() => {
+    runCodegenTask.mockReset()
+    trackCodeGeneration.mockReset()
+    process.env.INTERNAL_API_KEY = 'internal-key'
+    process.env.ANTHROPIC_API_KEY = 'anthropic-key'
+  })
+
+  afterEach(() => {
+    process.env.INTERNAL_API_KEY = originalInternal
+    process.env.ANTHROPIC_API_KEY = originalAnthropic
+  })
+
+  it('returns 500 when internal key is missing', async () => {
+    delete process.env.INTERNAL_API_KEY
+
+    const request = new NextRequest('http://localhost/api/anthropic/codegen', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        authorization: 'Bearer anything'
+      },
+      body: JSON.stringify({
+        instruction: 'generate code',
+        model: 'claude',
+        sessionId: 'session-1'
+      })
+    })
+
+    const response = await POST(request)
+    const body = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(body.error).toBe('Internal API key not configured')
+  })
+
+  it('returns 401 when authorization header is invalid', async () => {
+    const request = new NextRequest('http://localhost/api/anthropic/codegen', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        authorization: 'Bearer wrong-key'
+      },
+      body: JSON.stringify({
+        instruction: 'generate code',
+        model: 'claude',
+        sessionId: 'session-1'
+      })
+    })
+
+    const response = await POST(request)
+    const body = await response.json()
+
+    expect(response.status).toBe(401)
+    expect(body.error).toBe('Unauthorized access to code generation')
+  })
+
+  it('invokes code generation when authorized', async () => {
+    runCodegenTask.mockResolvedValueOnce({
+      success: true,
+      message: 'Done',
+      filesCreated: [{ path: 'index.ts' }],
+      error: null
+    })
+
+    const request = new NextRequest('http://localhost/api/anthropic/codegen', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        authorization: 'Bearer internal-key'
+      },
+      body: JSON.stringify({
+        instruction: 'generate code',
+        model: 'claude',
+        sessionId: 'session-1'
+      })
+    })
+
+    const response = await POST(request)
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.success).toBe(true)
+    expect(runCodegenTask).toHaveBeenCalledWith('generate code', 'claude')
+    expect(trackCodeGeneration).toHaveBeenCalled()
+  })
+})

--- a/tests/api/email-admin.test.ts
+++ b/tests/api/email-admin.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+const { findMany, aggregate, count, update } = vi.hoisted(() => ({
+  findMany: vi.fn(),
+  aggregate: vi.fn(),
+  count: vi.fn(),
+  update: vi.fn()
+}))
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    emailSubscriber: {
+      findMany,
+      aggregate,
+      count,
+      update
+    }
+  }
+}))
+
+import { GET, DELETE } from '../../app/api/emails/admin/route'
+
+describe('Email admin API', () => {
+  const originalAdminKey = process.env.EMAIL_ADMIN_KEY
+
+  beforeEach(() => {
+    findMany.mockReset()
+    aggregate.mockReset()
+    count.mockReset()
+    update.mockReset()
+    process.env.EMAIL_ADMIN_KEY = 'email-secret'
+  })
+
+  afterEach(() => {
+    process.env.EMAIL_ADMIN_KEY = originalAdminKey
+  })
+
+  it('fails with 500 when EMAIL_ADMIN_KEY is missing', async () => {
+    delete process.env.EMAIL_ADMIN_KEY
+
+    const request = new NextRequest('http://localhost/api/emails/admin')
+    const response = await GET(request)
+    const body = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(body.error).toBe('Email admin key not configured')
+  })
+
+  it('rejects unauthorized access', async () => {
+    const request = new NextRequest('http://localhost/api/emails/admin', {
+      headers: {
+        authorization: 'Bearer wrong'
+      }
+    })
+
+    const response = await GET(request)
+    const body = await response.json()
+
+    expect(response.status).toBe(401)
+    expect(body.error).toBe('Unauthorized')
+  })
+
+  it('returns subscriber data for authorized requests', async () => {
+    findMany.mockResolvedValueOnce([
+      {
+        id: 'sub-1',
+        email: 'user@example.com',
+        source: 'signup',
+        subscribedAt: new Date('2024-01-01T00:00:00Z'),
+        isActive: true
+      }
+    ])
+    aggregate.mockResolvedValueOnce({ _count: { id: 1 } })
+    count.mockResolvedValueOnce(1)
+
+    const request = new NextRequest('http://localhost/api/emails/admin', {
+      headers: {
+        authorization: 'Bearer email-secret'
+      }
+    })
+
+    const response = await GET(request)
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.subscribers).toHaveLength(1)
+    expect(body.statistics.total).toBe(1)
+  })
+
+  it('deactivates a subscriber when authorized', async () => {
+    update.mockResolvedValueOnce({
+      email: 'user@example.com'
+    })
+
+    const request = new NextRequest('http://localhost/api/emails/admin', {
+      method: 'DELETE',
+      headers: {
+        'Content-Type': 'application/json',
+        authorization: 'Bearer email-secret'
+      },
+      body: JSON.stringify({ email: 'user@example.com' })
+    })
+
+    const response = await DELETE(request)
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.email).toBe('user@example.com')
+    expect(update).toHaveBeenCalledWith({
+      where: { email: 'user@example.com' },
+      data: { isActive: false }
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- add a shared admin authorization helper and use it in the admin courses API and seed endpoint
- require configured secrets for the email admin routes and internal code generation entrypoints instead of default fallbacks
- add focused vitest coverage for the secured admin routes and codegen handler

## Testing
- `npx vitest run tests/api/admin-courses.test.ts tests/api/codegen.test.ts tests/api/email-admin.test.ts --reporter=default`


------
https://chatgpt.com/codex/tasks/task_e_68ca7df214dc8320b6db7c0ad9c16e7f